### PR TITLE
Fix: Vesting epoch logic from param

### DIFF
--- a/x/commitment/keeper/epoch_hooks.go
+++ b/x/commitment/keeper/epoch_hooks.go
@@ -10,15 +10,18 @@ func (k Keeper) BeforeEpochStart(_ sdk.Context, _ string, _ int64) {}
 
 // AfterEpochEnd distributes vested tokens at the end of each epoch
 func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, _ int64) {
-	logger := k.Logger(ctx)
-	logger.Info("Vestingg")
-	// check if epochIdentifier signal equals the identifier in the params
-	if epochIdentifier != "tenseconds" { // TODO gov param
-		return
-	}
 
-	if err := k.VestTokens(ctx); err != nil {
-		panic(err)
+	// Future Improvement: check all VestingInfos and get all VestingTokens by denom
+	// 	so we can iterate different denoms in different EpochIdentifiers
+	vestingInfo := k.GetVestingInfo(ctx, "ueden")
+	if vestingInfo != nil {
+		if epochIdentifier == vestingInfo.EpochIdentifier {
+			k.Logger(ctx).Info("Vesting tokens for vestingInfo", vestingInfo)
+			if err := k.VestTokens(ctx); err != nil {
+				k.Logger(ctx).Error("Error vesting tokens", "vestingInfo", vestingInfo)
+				panic(err)
+			}
+		}
 	}
 }
 

--- a/x/commitment/keeper/vest.go
+++ b/x/commitment/keeper/vest.go
@@ -7,10 +7,9 @@ import (
 )
 
 func (k Keeper) VestTokens(ctx sdk.Context) error {
-
+	// Future Improvement: get all VestingTokens by denom and iterate
 	k.IterateCommitments(ctx, func(commitments types.Commitments) (stop bool) {
 		logger := k.Logger(ctx)
-		logger.Info("insideiteratehandler")
 
 		for index := len(commitments.VestingTokens) - 1; index >= 0; index-- {
 			vesting := commitments.VestingTokens[index]


### PR DESCRIPTION
Removes a leftover TODO and pulls epochIdentifier from VestingInfo param. 
Removes leftover testing logs.

Manual test results:

```
~/elys$ elysd tx commitment vest 1000 ueden --from treasury

~/elys$ elysd q commitment show-commitments elys12tzylat4udvjj56uuhu3vj2n4vgp7cf9fwna9w
commitments:
  committed_tokens:
  - amount: "1000"
    denom: ueden
  creator: elys12tzylat4udvjj56uuhu3vj2n4vgp7cf9fwna9w
  uncommitted_tokens:
  - amount: "98000"
    denom: ueden
  vesting_tokens:
  - current_epoch: "0"
    denom: uelys
    epoch_identifier: tenseconds
    num_epochs: "10"
    total_amount: "1000"
    unvested_amount: "1000"
~/elys$ elysd q bank balances elys12tzylat4udvjj56uuhu3vj2n4vgp7cf9fwna9w
balances:
- amount: "100000000"
  denom: stake
- amount: "99900000"
  denom: ueden
- amount: "9000000000000100"
  denom: uelys
pagination:
  next_key: null
  total: "0"
~/elys$ elysd q commitment show-commitments elys12tzylat4udvjj56uuhu3vj2n4vgp7cf9fwna9w
commitments:
  committed_tokens:
  - amount: "1000"
    denom: ueden
  creator: elys12tzylat4udvjj56uuhu3vj2n4vgp7cf9fwna9w
  uncommitted_tokens:
  - amount: "98000"
    denom: ueden
  vesting_tokens:
  - current_epoch: "2"
    denom: uelys
    epoch_identifier: tenseconds
    num_epochs: "10"
    total_amount: "1000"
    unvested_amount: "800"
    `
```