### PR TITLE
chore: 🤖 fix conflicting latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME?=elys
 BINARY?=$(NAME)d
 COMMIT:=$(shell git log -1 --format='%H')
-VERSION:=$(shell git describe --tags --abbrev=8 | sed 's/-g/-/' | sed 's/-[0-9]*-/-/' | sed 's/v//')
+VERSION:=$(shell git describe --tags --match 'v*' --abbrev=8 | sed 's/-g/-/' | sed 's/-[0-9]*-/-/')
 
 GOFLAGS:=""
 GOTAGS:=ledger


### PR DESCRIPTION
# Problem

The `make build` and `make install` commands are selecting the wrong tag when multiple tags annotate the same commit hash. This results in an incorrect version number being used (e.g., selecting the `latest` tag instead of `v0.3.1`).

# Resolution

To resolve this issue, a pattern was added to the `make` commands to select the correct tag based on its name. This ensures that the correct version number is used in the build and installation process. As a result, the `make` commands now use the correct tag with the version information.

This PR also includes the `v` prefix to use in the displayed version.