### PR TITLE
Fixed go version check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ go.sum: go.mod
 
 # Add check to make sure we are using the proper Go version before proceeding with anything
 check-version:
-	@if ! go version | grep -q "go1.19"; then \
+	@if ! $(printf "%s\n" "$(go version | sed -n "s/.*go\([^ ]*\).*/\1/p")" "1.19" | sort -V -r | head -1) = "$(go version | sed -n "s/.*go\([^ ]*\).*/\1/p")"; then \
 		echo "\033[0;31mERROR:\033[0m Go version 1.19 is required for compiling elysd. It looks like you are using" "$(shell go version) \nThere are potential consensus-breaking changes that can occur when running binaries compiled with different versions of Go. Please download Go version 1.19 and retry. Thank you!"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Go version check was not catching the version properly.  I am on 1.20.X and it reported I was below 1.19.