### PR TITLE
fix: 🐛 disable incentive module hook causing panic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -663,7 +663,7 @@ func NewElysApp(
 			// insert epoch hooks receivers here
 			app.OracleKeeper.Hooks(),
 			app.CommitmentKeeper.Hooks(),
-			app.IncentiveKeeper.Hooks(),
+			// app.IncentiveKeeper.Hooks(),
 			app.BurnerKeeper.Hooks(),
 		),
 	)


### PR DESCRIPTION
due to non initiated params