### PR TITLE
Feat/incentive withdraw

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -70197,6 +70197,16 @@ definitions:
         type: string
         format: int64
     title: Incentive Info
+  elysnetwork.elys.incentive.MsgWithdrawRewardsResponse:
+    type: object
+    description: >-
+      MsgWithdrawDelegatorRewardResponse defines the Msg/WithdrawDelegatorReward
+      response type.
+  elysnetwork.elys.incentive.MsgWithdrawValidatorCommissionResponse:
+    type: object
+    description: >-
+      MsgWithdrawValidatorCommissionResponse defines the
+      Msg/WithdrawValidatorCommission response type.
   elysnetwork.elys.incentive.Params:
     type: object
     properties:

--- a/proto/elys/incentive/tx.proto
+++ b/proto/elys/incentive/tx.proto
@@ -2,11 +2,48 @@ syntax = "proto3";
 
 package elysnetwork.elys.incentive;
 
-import "cosmos/base/v1beta1/coin.proto";
 import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
 
 option go_package = "github.com/elys-network/elys/x/incentive/types";
 
 // Msg defines the Msg service.
 service Msg {
+    
+  // WithdrawDelegatorReward defines a method to withdraw rewards of delegator
+  // from a single validator.
+  rpc WithdrawRewards(MsgWithdrawRewards) returns (MsgWithdrawRewardsResponse);
+
+  // WithdrawValidatorCommission defines a method to withdraw the
+  // full commission to the validator address.
+  rpc WithdrawValidatorCommission(MsgWithdrawValidatorCommission) returns (MsgWithdrawValidatorCommissionResponse);
+
 }
+
+// MsgWithdrawDelegatorReward represents delegation withdrawal to a delegator
+// from a single validator.
+message MsgWithdrawRewards {
+    option (gogoproto.equal)           = false;
+    option (gogoproto.goproto_getters) = false;
+  
+    string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  }
+  
+  // MsgWithdrawDelegatorRewardResponse defines the Msg/WithdrawDelegatorReward response type.
+  message MsgWithdrawRewardsResponse {
+  }
+  
+  // MsgWithdrawValidatorCommission withdraws the full commission to the validator
+  // address.
+  message MsgWithdrawValidatorCommission {
+    option (gogoproto.equal)           = false;
+    option (gogoproto.goproto_getters) = false;
+  
+    string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  }
+  
+  // MsgWithdrawValidatorCommissionResponse defines the Msg/WithdrawValidatorCommission response type.
+  message MsgWithdrawValidatorCommissionResponse {
+  }
+  

--- a/x/commitment/keeper/msg_server_withdraw_tokens.go
+++ b/x/commitment/keeper/msg_server_withdraw_tokens.go
@@ -4,61 +4,13 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	aptypes "github.com/elys-network/elys/x/assetprofile/types"
 	"github.com/elys-network/elys/x/commitment/types"
 )
 
 func (k msgServer) WithdrawTokens(goCtx context.Context, msg *types.MsgWithdrawTokens) (*types.MsgWithdrawTokensResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	// Withdraw tokens
+	err := k.ProcessWithdrawTokens(ctx, msg.Creator, msg.Denom, msg.Amount)
 
-	assetProfile, found := k.apKeeper.GetEntry(ctx, msg.Denom)
-	if !found {
-		return nil, sdkerrors.Wrapf(aptypes.ErrAssetProfileNotFound, "denom: %s", msg.Denom)
-	}
-
-	if !assetProfile.WithdrawEnabled {
-		return nil, sdkerrors.Wrapf(types.ErrWithdrawDisabled, "denom: %s", msg.Denom)
-	}
-
-	commitments, err := k.DeductCommitments(ctx, msg.Creator, msg.Denom, msg.Amount)
-	if err != nil {
-		return nil, err
-	}
-	// Update the commitments
-	k.SetCommitments(ctx, commitments)
-
-	withdrawCoins := sdk.NewCoins(sdk.NewCoin(msg.Denom, msg.Amount))
-
-	// Mint the withdrawn tokens to the module account
-	err = k.bankKeeper.MintCoins(ctx, types.ModuleName, withdrawCoins)
-	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInsufficientFunds, "unable to mint withdrawn tokens")
-	}
-
-	addr, err := sdk.AccAddressFromBech32(commitments.Creator)
-	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "unable to convert address from bech32")
-	}
-
-	// Send the minted coins to the user's account
-	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, withdrawCoins)
-	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInsufficientFunds, "unable to send withdrawn tokens")
-	}
-
-	// Emit Hook commitment changed
-	k.AfterCommitmentChange(ctx, msg.Creator, sdk.NewCoin(msg.Denom, msg.Amount))
-
-	// Emit blockchain event
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			types.EventTypeCommitmentChanged,
-			sdk.NewAttribute(types.AttributeCreator, msg.Creator),
-			sdk.NewAttribute(types.AttributeAmount, msg.Amount.String()),
-			sdk.NewAttribute(types.AttributeDenom, msg.Denom),
-		),
-	)
-
-	return &types.MsgWithdrawTokensResponse{}, nil
+	return &types.MsgWithdrawTokensResponse{}, err
 }

--- a/x/incentive/client/cli/tx.go
+++ b/x/incentive/client/cli/tx.go
@@ -2,21 +2,31 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	// "github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/elys-network/elys/x/incentive/types"
 )
 
 var (
+	FlagCommission                        = "commission"
+	FlagValidatorAddress                  = "validator-address"
+	FlagMaxMessagesPerTx                  = "max-msgs"
 	DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
 )
 
 const (
 	flagPacketTimeoutTimestamp = "packet-timeout-timestamp"
+	MaxMessagesPerTxDefault    = 0
 	listSeparator              = ","
 )
 
@@ -29,7 +39,87 @@ func GetTxCmd() *cobra.Command {
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
+	cmd.AddCommand(
+		NewWithdrawRewardsCmd(),
+	)
+
 	// this line is used by starport scaffolding # 1
+
+	return cmd
+}
+
+type newGenerateOrBroadcastFunc func(client.Context, *pflag.FlagSet, ...sdk.Msg) error
+
+func newSplitAndApply(
+	genOrBroadcastFn newGenerateOrBroadcastFunc, clientCtx client.Context,
+	fs *pflag.FlagSet, msgs []sdk.Msg, chunkSize int,
+) error {
+	if chunkSize == 0 {
+		return genOrBroadcastFn(clientCtx, fs, msgs...)
+	}
+
+	// split messages into slices of length chunkSize
+	totalMessages := len(msgs)
+	for i := 0; i < len(msgs); i += chunkSize {
+
+		sliceEnd := i + chunkSize
+		if sliceEnd > totalMessages {
+			sliceEnd = totalMessages
+		}
+
+		msgChunk := msgs[i:sliceEnd]
+		if err := genOrBroadcastFn(clientCtx, fs, msgChunk...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewWithdrawRewardsCmd returns a CLI command handler for creating a MsgWithdrawDelegatorReward transaction.
+func NewWithdrawRewardsCmd() *cobra.Command {
+	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
+
+	cmd := &cobra.Command{
+		Use:   "withdraw-rewards",
+		Short: "Withdraw rewards from a given delegation address, and optionally withdraw validator commission if the delegation address given is a validator operator",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Withdraw rewards from a given delegation address,
+and optionally withdraw validator commission if the delegation address given is a validator operator.
+
+Example:
+$ %s tx incentive withdraw-rewards --from mykey
+$ %s tx incentive withdraw-rewards --from mykey --commission --validator-address %s1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+`,
+				version.AppName, bech32PrefixValAddr, bech32PrefixValAddr,
+			),
+		),
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+			delAddr := clientCtx.GetFromAddress()
+			msgs := []sdk.Msg{types.NewMsgWithdrawRewards(delAddr)}
+
+			if commission, _ := cmd.Flags().GetBool(FlagCommission); commission {
+				if validatorAddr, _ := cmd.Flags().GetString(FlagValidatorAddress); len(validatorAddr) > 0 {
+					valAddr, err := sdk.ValAddressFromBech32(validatorAddr)
+					if err != nil {
+						return err
+					}
+					msgs = append(msgs, types.NewMsgWithdrawValidatorCommission(delAddr, valAddr))
+				}
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msgs...)
+		},
+	}
+
+	cmd.Flags().Bool(FlagCommission, false, "Withdraw the validator's commission in addition to the rewards")
+	cmd.Flags().String(FlagValidatorAddress, "", "Validator's operator address to withdraw commission from")
+	flags.AddTxFlagsToCmd(cmd)
 
 	return cmd
 }

--- a/x/incentive/keeper/hooks_staking.go
+++ b/x/incentive/keeper/hooks_staking.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/elys-network/elys/x/incentive/types"
+	ptypes "github.com/elys-network/elys/x/parameter/types"
 )
 
 // Creating a commitment object for a delegator if one does not exist:
@@ -14,7 +14,7 @@ func (k Keeper) BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress,
 	}
 
 	// Create an entity in commitment module
-	k.cmk.StandardStakingToken(ctx, delAddr.String(), valAddr.String(), types.Eden)
+	k.cmk.StandardStakingToken(ctx, delAddr.String(), valAddr.String(), ptypes.Eden)
 
 	return nil
 }

--- a/x/incentive/keeper/msg_server.go
+++ b/x/incentive/keeper/msg_server.go
@@ -1,6 +1,10 @@
 package keeper
 
 import (
+	"context"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/elys-network/elys/x/incentive/types"
 )
 
@@ -15,3 +19,59 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 }
 
 var _ types.MsgServer = msgServer{}
+
+func (k msgServer) WithdrawRewards(goCtx context.Context, msg *types.MsgWithdrawRewards) (*types.MsgWithdrawRewardsResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	_, err := sdk.AccAddressFromBech32(msg.DelegatorAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	// Withdraw rewards
+	err = k.ProcessWithdrawRewards(ctx, msg.DelegatorAddress)
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.DelegatorAddress),
+		),
+	)
+	return &types.MsgWithdrawRewardsResponse{}, err
+}
+
+func (k msgServer) WithdrawValidatorCommission(goCtx context.Context, msg *types.MsgWithdrawValidatorCommission) (*types.MsgWithdrawValidatorCommissionResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	validatorAddr, err := sdk.ValAddressFromBech32(msg.ValidatorAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get owner of the validator address
+	validatorOwner := sdk.AccAddress(validatorAddr.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	delegator, err := sdk.AccAddressFromBech32(msg.DelegatorAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	// If it is not requested by the validator creator
+	if strings.EqualFold(validatorOwner.String(), delegator.String()) {
+		return &types.MsgWithdrawValidatorCommissionResponse{}, nil
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.ValidatorAddress),
+		),
+	)
+
+	return &types.MsgWithdrawValidatorCommissionResponse{}, nil
+}

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -17,6 +17,14 @@ type CommitmentKeeper interface {
 	SetCommitments(sdk.Context, ctypes.Commitments)
 	// Get commitment
 	GetCommitments(sdk.Context, string) (ctypes.Commitments, bool)
+	// Withdraw tokens
+	ProcessWithdrawTokens(sdk.Context, string, string, sdk.Int) error
+	// Withdraw USDC from Elys
+	ProcessWithdrawElysTokens(sdk.Context, string, string, sdk.Int) error
+	// Withdraw validator commission
+	ProcessWithdrawValidatorCommission(sdk.Context, string, string, string, sdk.Int) error
+	// Withdraw validator commission USDC from Elys
+	ProcessWithdrawValidatorElysCommission(sdk.Context, string, string, string, sdk.Int) error
 }
 
 // Staking keeper

--- a/x/incentive/types/keys.go
+++ b/x/incentive/types/keys.go
@@ -22,27 +22,6 @@ const (
 	MemStoreKey = "mem_incentive"
 )
 
-// Denom definition - Elys, Eden and Eden boost
-const (
-	// Eden denom
-	Elys = "uelys"
-
-	// Eden denom
-	Eden = "ueden"
-
-	// Eden Boost denom
-	EdenB = "uedenb"
-
-	// 52.1429 weeks
-	WeeksPerYear = 52
-
-	// 365 days
-	DaysPerYear = 365
-
-	// 8760 hours
-	HoursPerYear = 8760
-)
-
 func KeyPrefix(p string) []byte {
 	return []byte(p)
 }

--- a/x/incentive/types/msg.go
+++ b/x/incentive/types/msg.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// distribution message types
+const (
+	TypeMsgWithdrawRewards             = "withdraw_reward"
+	TypeMsgWithdrawValidatorCommission = "withdraw_validator_commission"
+)
+
+// Verify interface at compile time
+var _, _ sdk.Msg = &MsgWithdrawRewards{}, &MsgWithdrawValidatorCommission{}
+
+func NewMsgWithdrawRewards(delAddr sdk.AccAddress) *MsgWithdrawRewards {
+	return &MsgWithdrawRewards{
+		DelegatorAddress: delAddr.String(),
+	}
+}
+
+func (msg MsgWithdrawRewards) Route() string { return ModuleName }
+func (msg MsgWithdrawRewards) Type() string  { return TypeMsgWithdrawRewards }
+
+// Return address that must sign over msg.GetSignBytes()
+func (msg MsgWithdrawRewards) GetSigners() []sdk.AccAddress {
+	delegator, _ := sdk.AccAddressFromBech32(msg.DelegatorAddress)
+	return []sdk.AccAddress{delegator}
+}
+
+// get the bytes for the message signer to sign on
+func (msg MsgWithdrawRewards) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// quick validity check
+func (msg MsgWithdrawRewards) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.DelegatorAddress); err != nil {
+		return sdkerrors.ErrInvalidAddress.Wrapf("invalid delegator address: %s", err)
+	}
+	return nil
+}
+
+func NewMsgWithdrawValidatorCommission(delAddr sdk.AccAddress, valAddr sdk.ValAddress) *MsgWithdrawValidatorCommission {
+	return &MsgWithdrawValidatorCommission{
+		DelegatorAddress: delAddr.String(),
+		ValidatorAddress: valAddr.String(),
+	}
+}
+
+func (msg MsgWithdrawValidatorCommission) Route() string { return ModuleName }
+func (msg MsgWithdrawValidatorCommission) Type() string  { return TypeMsgWithdrawValidatorCommission }
+
+// Return address that must sign over msg.GetSignBytes()
+func (msg MsgWithdrawValidatorCommission) GetSigners() []sdk.AccAddress {
+	valAddr, _ := sdk.ValAddressFromBech32(msg.ValidatorAddress)
+	return []sdk.AccAddress{sdk.AccAddress(valAddr)}
+}
+
+// get the bytes for the message signer to sign on
+func (msg MsgWithdrawValidatorCommission) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// quick validity check
+func (msg MsgWithdrawValidatorCommission) ValidateBasic() error {
+	if _, err := sdk.ValAddressFromBech32(msg.ValidatorAddress); err != nil {
+		return sdkerrors.ErrInvalidAddress.Wrapf("invalid validator address: %s", err)
+	}
+	if _, err := sdk.AccAddressFromBech32(msg.DelegatorAddress); err != nil {
+		return sdkerrors.ErrInvalidAddress.Wrapf("invalid delegator address: %s", err)
+	}
+	return nil
+}

--- a/x/incentive/types/tx.pb.go
+++ b/x/incentive/types/tx.pb.go
@@ -6,12 +6,16 @@ package types
 import (
 	context "context"
 	fmt "fmt"
-	_ "github.com/cosmos/cosmos-sdk/types"
+	_ "github.com/cosmos/cosmos-proto"
 	_ "github.com/gogo/protobuf/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"
 	proto "github.com/gogo/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -25,21 +29,194 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// MsgWithdrawDelegatorReward represents delegation withdrawal to a delegator
+// from a single validator.
+type MsgWithdrawRewards struct {
+	DelegatorAddress string `protobuf:"bytes,1,opt,name=delegator_address,json=delegatorAddress,proto3" json:"delegator_address,omitempty"`
+}
+
+func (m *MsgWithdrawRewards) Reset()         { *m = MsgWithdrawRewards{} }
+func (m *MsgWithdrawRewards) String() string { return proto.CompactTextString(m) }
+func (*MsgWithdrawRewards) ProtoMessage()    {}
+func (*MsgWithdrawRewards) Descriptor() ([]byte, []int) {
+	return fileDescriptor_59dc3bedfb1cce84, []int{0}
+}
+func (m *MsgWithdrawRewards) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgWithdrawRewards) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgWithdrawRewards.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgWithdrawRewards) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithdrawRewards.Merge(m, src)
+}
+func (m *MsgWithdrawRewards) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgWithdrawRewards) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgWithdrawRewards.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgWithdrawRewards proto.InternalMessageInfo
+
+// MsgWithdrawDelegatorRewardResponse defines the Msg/WithdrawDelegatorReward response type.
+type MsgWithdrawRewardsResponse struct {
+}
+
+func (m *MsgWithdrawRewardsResponse) Reset()         { *m = MsgWithdrawRewardsResponse{} }
+func (m *MsgWithdrawRewardsResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgWithdrawRewardsResponse) ProtoMessage()    {}
+func (*MsgWithdrawRewardsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_59dc3bedfb1cce84, []int{1}
+}
+func (m *MsgWithdrawRewardsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgWithdrawRewardsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgWithdrawRewardsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgWithdrawRewardsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithdrawRewardsResponse.Merge(m, src)
+}
+func (m *MsgWithdrawRewardsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgWithdrawRewardsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgWithdrawRewardsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgWithdrawRewardsResponse proto.InternalMessageInfo
+
+// MsgWithdrawValidatorCommission withdraws the full commission to the validator
+// address.
+type MsgWithdrawValidatorCommission struct {
+	DelegatorAddress string `protobuf:"bytes,1,opt,name=delegator_address,json=delegatorAddress,proto3" json:"delegator_address,omitempty"`
+	ValidatorAddress string `protobuf:"bytes,2,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
+}
+
+func (m *MsgWithdrawValidatorCommission) Reset()         { *m = MsgWithdrawValidatorCommission{} }
+func (m *MsgWithdrawValidatorCommission) String() string { return proto.CompactTextString(m) }
+func (*MsgWithdrawValidatorCommission) ProtoMessage()    {}
+func (*MsgWithdrawValidatorCommission) Descriptor() ([]byte, []int) {
+	return fileDescriptor_59dc3bedfb1cce84, []int{2}
+}
+func (m *MsgWithdrawValidatorCommission) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgWithdrawValidatorCommission) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgWithdrawValidatorCommission.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgWithdrawValidatorCommission) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithdrawValidatorCommission.Merge(m, src)
+}
+func (m *MsgWithdrawValidatorCommission) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgWithdrawValidatorCommission) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgWithdrawValidatorCommission.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgWithdrawValidatorCommission proto.InternalMessageInfo
+
+// MsgWithdrawValidatorCommissionResponse defines the Msg/WithdrawValidatorCommission response type.
+type MsgWithdrawValidatorCommissionResponse struct {
+}
+
+func (m *MsgWithdrawValidatorCommissionResponse) Reset() {
+	*m = MsgWithdrawValidatorCommissionResponse{}
+}
+func (m *MsgWithdrawValidatorCommissionResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgWithdrawValidatorCommissionResponse) ProtoMessage()    {}
+func (*MsgWithdrawValidatorCommissionResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_59dc3bedfb1cce84, []int{3}
+}
+func (m *MsgWithdrawValidatorCommissionResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgWithdrawValidatorCommissionResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgWithdrawValidatorCommissionResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgWithdrawValidatorCommissionResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithdrawValidatorCommissionResponse.Merge(m, src)
+}
+func (m *MsgWithdrawValidatorCommissionResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgWithdrawValidatorCommissionResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgWithdrawValidatorCommissionResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgWithdrawValidatorCommissionResponse proto.InternalMessageInfo
+
+func init() {
+	proto.RegisterType((*MsgWithdrawRewards)(nil), "elysnetwork.elys.incentive.MsgWithdrawRewards")
+	proto.RegisterType((*MsgWithdrawRewardsResponse)(nil), "elysnetwork.elys.incentive.MsgWithdrawRewardsResponse")
+	proto.RegisterType((*MsgWithdrawValidatorCommission)(nil), "elysnetwork.elys.incentive.MsgWithdrawValidatorCommission")
+	proto.RegisterType((*MsgWithdrawValidatorCommissionResponse)(nil), "elysnetwork.elys.incentive.MsgWithdrawValidatorCommissionResponse")
+}
+
 func init() { proto.RegisterFile("elys/incentive/tx.proto", fileDescriptor_59dc3bedfb1cce84) }
 
 var fileDescriptor_59dc3bedfb1cce84 = []byte{
-	// 174 bytes of a gzipped FileDescriptorProto
+	// 351 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x4f, 0xcd, 0xa9, 0x2c,
 	0xd6, 0xcf, 0xcc, 0x4b, 0x4e, 0xcd, 0x2b, 0xc9, 0x2c, 0x4b, 0xd5, 0x2f, 0xa9, 0xd0, 0x2b, 0x28,
 	0xca, 0x2f, 0xc9, 0x17, 0x92, 0x02, 0x49, 0xe4, 0xa5, 0x96, 0x94, 0xe7, 0x17, 0x65, 0xeb, 0x81,
-	0xd8, 0x7a, 0x70, 0x45, 0x52, 0x72, 0xc9, 0xf9, 0xc5, 0xb9, 0xf9, 0xc5, 0xfa, 0x49, 0x89, 0xc5,
-	0xa9, 0xfa, 0x65, 0x86, 0x49, 0xa9, 0x25, 0x89, 0x86, 0xfa, 0xc9, 0xf9, 0x99, 0x79, 0x10, 0xbd,
-	0x52, 0x22, 0xe9, 0xf9, 0xe9, 0xf9, 0x60, 0xa6, 0x3e, 0x88, 0x05, 0x11, 0x35, 0x62, 0xe5, 0x62,
-	0xf6, 0x2d, 0x4e, 0x77, 0xf2, 0x38, 0xf1, 0x48, 0x8e, 0xf1, 0xc2, 0x23, 0x39, 0xc6, 0x07, 0x8f,
+	0xd8, 0x7a, 0x70, 0x45, 0x52, 0x22, 0xe9, 0xf9, 0xe9, 0xf9, 0x60, 0x65, 0xfa, 0x20, 0x16, 0x44,
+	0x87, 0x94, 0x64, 0x72, 0x7e, 0x71, 0x6e, 0x7e, 0x71, 0x3c, 0x44, 0x02, 0xc2, 0x81, 0x48, 0x29,
+	0xa5, 0x72, 0x09, 0xf9, 0x16, 0xa7, 0x87, 0x67, 0x96, 0x64, 0xa4, 0x14, 0x25, 0x96, 0x07, 0xa5,
+	0x96, 0x27, 0x16, 0xa5, 0x14, 0x0b, 0xb9, 0x72, 0x09, 0xa6, 0xa4, 0xe6, 0xa4, 0xa6, 0x27, 0x96,
+	0xe4, 0x17, 0xc5, 0x27, 0xa6, 0xa4, 0x14, 0xa5, 0x16, 0x17, 0x4b, 0x30, 0x2a, 0x30, 0x6a, 0x70,
+	0x3a, 0x49, 0x5c, 0xda, 0xa2, 0x2b, 0x02, 0x35, 0xc2, 0x11, 0x22, 0x13, 0x5c, 0x52, 0x94, 0x99,
+	0x97, 0x1e, 0x24, 0x00, 0xd7, 0x02, 0x15, 0xb7, 0xe2, 0xe8, 0x58, 0x20, 0xcf, 0xf0, 0x62, 0x81,
+	0x3c, 0x83, 0x92, 0x0c, 0x97, 0x14, 0xa6, 0x35, 0x41, 0xa9, 0xc5, 0x05, 0xf9, 0x79, 0xc5, 0xa9,
+	0x4a, 0x3b, 0x18, 0xb9, 0xe4, 0x90, 0xa4, 0xc3, 0x12, 0x73, 0x32, 0x53, 0x40, 0xe6, 0x38, 0xe7,
+	0xe7, 0xe6, 0x66, 0x16, 0x17, 0x67, 0xe6, 0xe7, 0x51, 0xc9, 0x45, 0x20, 0x63, 0xca, 0x60, 0xa6,
+	0xc3, 0x8d, 0x61, 0x22, 0x64, 0x0c, 0x5c, 0x0b, 0xa6, 0xc7, 0x34, 0xb8, 0xd4, 0xf0, 0xbb, 0x1c,
+	0xe6, 0x49, 0xa3, 0x05, 0x4c, 0x5c, 0xcc, 0xbe, 0xc5, 0xe9, 0x42, 0x95, 0x5c, 0xfc, 0xe8, 0xc1,
+	0xad, 0xa7, 0x87, 0x3b, 0x4a, 0xf5, 0x30, 0xc3, 0x4d, 0xca, 0x8c, 0x34, 0xf5, 0x30, 0x27, 0x08,
+	0xcd, 0x65, 0xe4, 0x92, 0xc6, 0x17, 0xc8, 0x56, 0x44, 0x9a, 0x8b, 0x45, 0xaf, 0x94, 0x13, 0xf9,
+	0x7a, 0x61, 0xee, 0x73, 0xf2, 0x38, 0xf1, 0x48, 0x8e, 0xf1, 0xc2, 0x23, 0x39, 0xc6, 0x07, 0x8f,
 	0xe4, 0x18, 0x27, 0x3c, 0x96, 0x63, 0xb8, 0xf0, 0x58, 0x8e, 0xe1, 0xc6, 0x63, 0x39, 0x86, 0x28,
-	0xbd, 0xf4, 0xcc, 0x92, 0x8c, 0xd2, 0x24, 0xbd, 0xe4, 0xfc, 0x5c, 0x7d, 0x90, 0x8d, 0xba, 0x50,
-	0xeb, 0xc1, 0x1c, 0xfd, 0x0a, 0x64, 0x57, 0x56, 0x16, 0xa4, 0x16, 0x27, 0xb1, 0x81, 0xcd, 0x35,
-	0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0xd2, 0xfd, 0x78, 0x3b, 0xc4, 0x00, 0x00, 0x00,
+	0xbd, 0xf4, 0xcc, 0x92, 0x8c, 0xd2, 0x24, 0xbd, 0xe4, 0xfc, 0x5c, 0x7d, 0x90, 0xd9, 0xba, 0x50,
+	0x8b, 0xc0, 0x1c, 0xfd, 0x0a, 0xe4, 0x6c, 0x52, 0x59, 0x90, 0x5a, 0x9c, 0xc4, 0x06, 0x4e, 0xdd,
+	0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0x63, 0xc3, 0x48, 0xfa, 0x45, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -54,6 +231,12 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
+	// WithdrawDelegatorReward defines a method to withdraw rewards of delegator
+	// from a single validator.
+	WithdrawRewards(ctx context.Context, in *MsgWithdrawRewards, opts ...grpc.CallOption) (*MsgWithdrawRewardsResponse, error)
+	// WithdrawValidatorCommission defines a method to withdraw the
+	// full commission to the validator address.
+	WithdrawValidatorCommission(ctx context.Context, in *MsgWithdrawValidatorCommission, opts ...grpc.CallOption) (*MsgWithdrawValidatorCommissionResponse, error)
 }
 
 type msgClient struct {
@@ -64,22 +247,657 @@ func NewMsgClient(cc grpc1.ClientConn) MsgClient {
 	return &msgClient{cc}
 }
 
+func (c *msgClient) WithdrawRewards(ctx context.Context, in *MsgWithdrawRewards, opts ...grpc.CallOption) (*MsgWithdrawRewardsResponse, error) {
+	out := new(MsgWithdrawRewardsResponse)
+	err := c.cc.Invoke(ctx, "/elysnetwork.elys.incentive.Msg/WithdrawRewards", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *msgClient) WithdrawValidatorCommission(ctx context.Context, in *MsgWithdrawValidatorCommission, opts ...grpc.CallOption) (*MsgWithdrawValidatorCommissionResponse, error) {
+	out := new(MsgWithdrawValidatorCommissionResponse)
+	err := c.cc.Invoke(ctx, "/elysnetwork.elys.incentive.Msg/WithdrawValidatorCommission", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
+	// WithdrawDelegatorReward defines a method to withdraw rewards of delegator
+	// from a single validator.
+	WithdrawRewards(context.Context, *MsgWithdrawRewards) (*MsgWithdrawRewardsResponse, error)
+	// WithdrawValidatorCommission defines a method to withdraw the
+	// full commission to the validator address.
+	WithdrawValidatorCommission(context.Context, *MsgWithdrawValidatorCommission) (*MsgWithdrawValidatorCommissionResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
 type UnimplementedMsgServer struct {
 }
 
+func (*UnimplementedMsgServer) WithdrawRewards(ctx context.Context, req *MsgWithdrawRewards) (*MsgWithdrawRewardsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method WithdrawRewards not implemented")
+}
+func (*UnimplementedMsgServer) WithdrawValidatorCommission(ctx context.Context, req *MsgWithdrawValidatorCommission) (*MsgWithdrawValidatorCommissionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method WithdrawValidatorCommission not implemented")
+}
+
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
 	s.RegisterService(&_Msg_serviceDesc, srv)
+}
+
+func _Msg_WithdrawRewards_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgWithdrawRewards)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).WithdrawRewards(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/elysnetwork.elys.incentive.Msg/WithdrawRewards",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).WithdrawRewards(ctx, req.(*MsgWithdrawRewards))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Msg_WithdrawValidatorCommission_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgWithdrawValidatorCommission)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).WithdrawValidatorCommission(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/elysnetwork.elys.incentive.Msg/WithdrawValidatorCommission",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).WithdrawValidatorCommission(ctx, req.(*MsgWithdrawValidatorCommission))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "elysnetwork.elys.incentive.Msg",
 	HandlerType: (*MsgServer)(nil),
-	Methods:     []grpc.MethodDesc{},
-	Streams:     []grpc.StreamDesc{},
-	Metadata:    "elys/incentive/tx.proto",
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "WithdrawRewards",
+			Handler:    _Msg_WithdrawRewards_Handler,
+		},
+		{
+			MethodName: "WithdrawValidatorCommission",
+			Handler:    _Msg_WithdrawValidatorCommission_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "elys/incentive/tx.proto",
 }
+
+func (m *MsgWithdrawRewards) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgWithdrawRewards) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgWithdrawRewards) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.DelegatorAddress) > 0 {
+		i -= len(m.DelegatorAddress)
+		copy(dAtA[i:], m.DelegatorAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.DelegatorAddress)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgWithdrawRewardsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgWithdrawRewardsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgWithdrawRewardsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgWithdrawValidatorCommission) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgWithdrawValidatorCommission) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgWithdrawValidatorCommission) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.ValidatorAddress) > 0 {
+		i -= len(m.ValidatorAddress)
+		copy(dAtA[i:], m.ValidatorAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.ValidatorAddress)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.DelegatorAddress) > 0 {
+		i -= len(m.DelegatorAddress)
+		copy(dAtA[i:], m.DelegatorAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.DelegatorAddress)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgWithdrawValidatorCommissionResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgWithdrawValidatorCommissionResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgWithdrawValidatorCommissionResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
+	offset -= sovTx(v)
+	base := offset
+	for v >= 1<<7 {
+		dAtA[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	dAtA[offset] = uint8(v)
+	return base
+}
+func (m *MsgWithdrawRewards) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DelegatorAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgWithdrawRewardsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgWithdrawValidatorCommission) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DelegatorAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.ValidatorAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgWithdrawValidatorCommissionResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func sovTx(x uint64) (n int) {
+	return (math_bits.Len64(x|1) + 6) / 7
+}
+func sozTx(x uint64) (n int) {
+	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *MsgWithdrawRewards) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgWithdrawRewards: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgWithdrawRewards: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DelegatorAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DelegatorAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgWithdrawRewardsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgWithdrawRewardsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgWithdrawRewardsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgWithdrawValidatorCommission) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgWithdrawValidatorCommission: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgWithdrawValidatorCommission: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DelegatorAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DelegatorAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValidatorAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ValidatorAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgWithdrawValidatorCommissionResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgWithdrawValidatorCommissionResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgWithdrawValidatorCommissionResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func skipTx(dAtA []byte) (n int, err error) {
+	l := len(dAtA)
+	iNdEx := 0
+	depth := 0
+	for iNdEx < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return 0, ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return 0, io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		wireType := int(wire & 0x7)
+		switch wireType {
+		case 0:
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return 0, ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return 0, io.ErrUnexpectedEOF
+				}
+				iNdEx++
+				if dAtA[iNdEx-1] < 0x80 {
+					break
+				}
+			}
+		case 1:
+			iNdEx += 8
+		case 2:
+			var length int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return 0, ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return 0, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				length |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if length < 0 {
+				return 0, ErrInvalidLengthTx
+			}
+			iNdEx += length
+		case 3:
+			depth++
+		case 4:
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupTx
+			}
+			depth--
+		case 5:
+			iNdEx += 4
+		default:
+			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
+		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthTx
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
+	}
+	return 0, io.ErrUnexpectedEOF
+}
+
+var (
+	ErrInvalidLengthTx        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowTx          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupTx = fmt.Errorf("proto: unexpected end of group")
+)

--- a/x/parameter/types/keys.go
+++ b/x/parameter/types/keys.go
@@ -21,6 +21,29 @@ const (
 	AnteStoreKey = "ante-handler-param"
 )
 
+const (
+	// Eden denom
+	Elys = "uelys"
+
+	// Eden denom
+	Eden = "ueden"
+
+	// Eden Boost denom
+	EdenB = "uedenb"
+	
+	// USDC
+	USDC = "usdc"
+
+	// 52.1429 weeks
+	WeeksPerYear = 52
+
+	// 365 days
+	DaysPerYear = 365
+
+	// 8760 hours
+	HoursPerYear = 8760
+)
+
 var _ binary.ByteOrder
 
 func KeyPrefix(p string) []byte {


### PR DESCRIPTION
- having one withdraw function to claim all types of rewards
- use flag --commission along with --validator-address and we can claim validator's commission
- updated commitment module to export necessary withdraw functions
- placeholder for the conversion of Elys to USDC.
- move all token denom declaration to parameter module.