### PR TITLE
Adding PowerApproximation function

### DIFF
--- a/x/amm/types/constants.go
+++ b/x/amm/types/constants.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
@@ -17,9 +18,19 @@ var (
 	// InitPoolSharesSupply is the amount of new shares to initialize a pool with.
 	InitPoolSharesSupply = OneShare.MulRaw(100)
 
-	// Scaling factor for every weight. The pool weight is:
+	// GuaranteedWeightPrecision Scaling factor for every weight. The pool weight is:
 	// weight_in_MsgCreateBalancerPool * GuaranteedWeightPrecision
 	//
 	// This is done so that smooth weight changes have enough precision to actually be smooth.
 	GuaranteedWeightPrecision int64 = 1 << 30
+
+	oneHalf    = sdk.MustNewDecFromStr("0.5")
+	twoDec     = sdk.MustNewDecFromStr("2")
+	ln2        = sdk.MustNewDecFromStr("0.693147180559945309")
+	inverseLn2 = sdk.MustNewDecFromStr("1.442695040888963407")
+	exp        = sdk.MustNewDecFromStr("2.718281828459045235")
+
+	// PowPrecision Don't EVER change after initializing
+	// TODO: Analyze choice here.
+	powPrecision = sdk.MustNewDecFromStr("0.00000001")
 )

--- a/x/amm/types/constants.go
+++ b/x/amm/types/constants.go
@@ -24,11 +24,12 @@ var (
 	// This is done so that smooth weight changes have enough precision to actually be smooth.
 	GuaranteedWeightPrecision int64 = 1 << 30
 
-	oneHalf    = sdk.MustNewDecFromStr("0.5")
-	twoDec     = sdk.MustNewDecFromStr("2")
-	ln2        = sdk.MustNewDecFromStr("0.693147180559945309")
-	inverseLn2 = sdk.MustNewDecFromStr("1.442695040888963407")
-	exp        = sdk.MustNewDecFromStr("2.718281828459045235")
+	oneHalf           = sdk.MustNewDecFromStr("0.5")
+	twoDec            = sdk.MustNewDecFromStr("2")
+	ln2               = sdk.MustNewDecFromStr("0.693147180559945309")
+	inverseLn2        = sdk.MustNewDecFromStr("1.442695040888963407")
+	euler             = sdk.MustNewDecFromStr("2.718281828459045235")
+	powIterationLimit = int64(150_000)
 
 	// PowPrecision Don't EVER change after initializing
 	// TODO: Analyze choice here.

--- a/x/amm/types/pow.go
+++ b/x/amm/types/pow.go
@@ -45,7 +45,7 @@ func Pow(base sdk.Dec, exp sdk.Dec) sdk.Dec {
 		return integerPow
 	}
 
-	fractionalPow := PowApprox(base, fractional, powPrecision)
+	fractionalPow := PowerApproximation(base, fractional)
 
 	return integerPow.Mul(fractionalPow)
 }

--- a/x/amm/types/pow.go
+++ b/x/amm/types/pow.go
@@ -45,7 +45,10 @@ func Pow(base sdk.Dec, exp sdk.Dec) sdk.Dec {
 		return integerPow
 	}
 
-	fractionalPow := PowerApproximation(base, fractional)
+	fractionalPow, err := PowerApproximation(base, fractional)
+	if err != nil {
+		panic(err)
+	}
 
 	return integerPow.Mul(fractionalPow)
 }

--- a/x/amm/types/pow.go
+++ b/x/amm/types/pow.go
@@ -31,7 +31,7 @@ func Pow(base sdk.Dec, exp sdk.Dec) sdk.Dec {
 		return integerPow
 	}
 
-	fractionalPow, err := PowerApproximation(base, fractional)
+	fractionalPow, err := powerApproximation(base, fractional)
 	if err != nil {
 		panic(err)
 	}

--- a/x/amm/types/pow.go
+++ b/x/amm/types/pow.go
@@ -6,20 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// Don't EVER change after initializing
-// TODO: Analyze choice here.
-var powPrecision, _ = sdk.NewDecFromStr("0.00000001")
-
-var (
-	one_half sdk.Dec = sdk.MustNewDecFromStr("0.5")
-	one      sdk.Dec = sdk.OneDec()
-	two      sdk.Dec = sdk.MustNewDecFromStr("2")
-
-	// https://www.wolframalpha.com/input?i=2.718281828459045235360287471352662498&assumption=%22ClashPrefs%22+-%3E+%7B%22Math%22%7D
-	// nolint: unused
-	// eulersNumber = sdk.MustNewDecFromStr("2.718281828459045235360287471352662498")
-)
-
 // Pow computes base^(exp)
 // However since the exponent is not an integer, we must do an approximation algorithm.
 // TODO: In the future, lets add some optimized routines for common exponents, e.g. for common wIn / wOut ratios

--- a/x/amm/types/pow_approx.go
+++ b/x/amm/types/pow_approx.go
@@ -65,7 +65,6 @@ func computeLn(x sdk.Dec) sdk.Dec {
 }
 
 // PowerApproximation This uses formula z = exp(b * ComputeLn(a)) for a^b.
-// `terms` increases the accuracy of ComputeLn(a)
 func PowerApproximation(base sdk.Dec, exp sdk.Dec) sdk.Dec {
 	if !base.IsPositive() {
 		panic(fmt.Errorf("base must be greater than 0"))

--- a/x/amm/types/pow_approx.go
+++ b/x/amm/types/pow_approx.go
@@ -1,9 +1,10 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"math"
+	"strconv"
 )
 
 func computeExp(x sdk.Dec) (sdk.Dec, error) {
@@ -11,7 +12,7 @@ func computeExp(x sdk.Dec) (sdk.Dec, error) {
 		return sdk.OneDec(), nil
 	}
 	if x.Equal(sdk.OneDec()) {
-		return exp, nil
+		return euler, nil
 	}
 	// exp(-42) is approx 5.7 x 10^-19, smallest dec possible is 10^-18
 	if x.LTE(sdk.NewDecFromInt(sdk.NewInt(-42))) {
@@ -26,11 +27,14 @@ func computeExp(x sdk.Dec) (sdk.Dec, error) {
 	term := sdk.OneDec()
 
 	//n decides the precision of the value, higher the n, greater is the accuracy
-	for n := int64(1); n <= 100; n++ {
+	for n := int64(1); ; n++ {
 		term = term.Mul(y).QuoInt64(n)
 		expY = expY.Add(term)
 		if term.Abs().LTE(powPrecision) {
 			break
+		}
+		if n > powIterationLimit {
+			return sdk.Dec{}, fmt.Errorf("failed to reach precision within %d iterations while comuting Exp for: %s", powIterationLimit, x.String())
 		}
 	}
 
@@ -47,17 +51,8 @@ func computeExp(x sdk.Dec) (sdk.Dec, error) {
 }
 
 func computeLn(x sdk.Dec) (result sdk.Dec, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			var ok bool
-			err, ok = r.(error)
-			if !ok {
-				err = errors.New("out of bounds")
-			}
-		}
-	}()
 	if x.LTE(sdk.ZeroDec()) {
-		panic("x must be greater than 0")
+		return sdk.Dec{}, fmt.Errorf("x for computing it's Ln must be greater than 0")
 	}
 	if x.Equal(sdk.OneDec()) {
 		return sdk.ZeroDec(), nil
@@ -70,7 +65,7 @@ func computeLn(x sdk.Dec) (result sdk.Dec, err error) {
 		x = x.Quo(twoDec)
 		k++
 	}
-	for x.LT(sdk.OneDec().Quo(twoDec)) {
+	for x.LT(oneHalf) {
 		x = x.MulInt64(2)
 		k--
 	}
@@ -81,17 +76,21 @@ func computeLn(x sdk.Dec) (result sdk.Dec, err error) {
 	// maximum value of y is 1
 	// Though n doesn't have upper cap, this iteration will break as |y| < 1,
 	// if y is very close to 1 it will large number of iterations
-	for n := uint64(1); ; n++ {
+	for n := int64(1); ; n++ {
 		sign := sdk.NewInt(-1)
 		if (n+1)%2 == 0 {
 			sign = sdk.OneInt()
 		}
-		term := yPower.MulInt(sign).QuoInt64(int64(n))
+		term := yPower.MulInt(sign).QuoInt64(n)
 		result = result.Add(term)
 		// This won't work if y > 1 because absolute value of term is (y^n)/n,
 		// if y > 1, it's an increasing value
 		if powPrecision.GT(term.Abs()) {
 			break
+		}
+
+		if n > powIterationLimit {
+			return sdk.Dec{}, fmt.Errorf("failed to reach precision within %d iterations while comuting Ln for: %s", powIterationLimit, x.String())
 		}
 
 		yPower = yPower.Mul(y)
@@ -100,11 +99,105 @@ func computeLn(x sdk.Dec) (result sdk.Dec, err error) {
 	return result.Add(ln2.MulInt64(int64(k))), nil
 }
 
-func PowerApproximation(base sdk.Dec, exp sdk.Dec) (sdk.Dec, error) {
+func PowApprox(originalBase sdk.Dec, exp sdk.Dec, precision sdk.Dec) sdk.Dec {
+	if !originalBase.IsPositive() {
+		panic(fmt.Errorf("base must be greater than 0"))
+	}
+
+	if exp.IsZero() {
+		return sdk.OneDec()
+	}
+
+	// Common case optimization
+	// Optimize for it being equal to one-half
+	if exp.Equal(oneHalf) {
+		output, err := originalBase.ApproxSqrt()
+		if err != nil {
+			panic(err)
+		}
+		return output
+	}
+	// TODO: Make an approx-equal function, and then check if exp * 3 = 1, and do a check accordingly
+
+	// We compute this via taking the maclaurin series of (1 + x)^a
+	// where x = base - 1.
+	// The maclaurin series of (1 + x)^a = sum_{k=0}^{infty} binom(a, k) x^k
+	// Binom(a, k) takes the natural continuation on the first parameter, namely that
+	// Binom(a, k) = N/D, where D = k!, and N = a(a-1)(a-2)...(a-k+1)
+	// Next we show that the absolute value of each term is less than the last term.
+	// Note that the change in term n's value vs term n + 1 is a multiplicative factor of
+	// v_n = x(a - n) / (n+1)
+	// So if |v_n| < 1, we know that each term has a lesser impact on the result than the last.
+	// For our bounds on |x| < 1, |a| < 1,
+	// it suffices to see for what n is |v_n| < 1,
+	// in the worst parameterization of x = 1, a = -1.
+	// v_n = |(-1 + epsilon - n) / (n+1)|
+	// So |v_n| is always less than 1, as n ranges over the integers.
+	//
+	// Note that term_n of the expansion is 1 * prod_{i=0}^{n-1} v_i
+	// The error if we stop the expansion at term_n is:
+	// error_n = sum_{k=n+1}^{infty} term_k
+	// At this point we further restrict a >= 0, so 0 <= a < 1.
+	// Now we take the _INCORRECT_ assumption that if term_n < p, then
+	// error_n < p.
+	// This assumption is obviously wrong.
+	// However our usages of this function don't use the full domain.
+	// With a > 0, |x| << 1, and p sufficiently low, perhaps this actually is true.
+
+	// TODO: Check with our parameterization
+	// TODO: If there's a bug, balancer is also wrong here :thonk:
+
+	base := originalBase.Clone()
+	x, xneg := AbsDifferenceWithSign(base, sdk.OneDec())
+	term := sdk.OneDec()
+	sum := sdk.OneDec()
+	negative := false
+
+	a := exp.Clone()
+	bigK := sdk.NewDec(0)
+	// TODO: Document this computation via taylor expansion
+	for i := int64(1); term.GTE(precision); i++ {
+		// At each iteration, we need two values, i and i-1.
+		// To avoid expensive big.Int allocation, we reuse bigK variable.
+		// On this line, bigK == i-1.
+		c, cneg := AbsDifferenceWithSign(a, bigK)
+		// On this line, bigK == i.
+		bigK.SetInt64(i)
+		term.MulMut(c).MulMut(x).QuoMut(bigK)
+
+		// a is mutated on absDifferenceWithSign, reset
+		a.Set(exp)
+
+		if term.IsZero() {
+			break
+		}
+		if xneg {
+			negative = !negative
+		}
+
+		if cneg {
+			negative = !negative
+		}
+
+		if negative {
+			sum.SubMut(term)
+		} else {
+			sum.AddMut(term)
+		}
+
+		if i == powIterationLimit {
+			panic(fmt.Errorf("failed to reach precision within %d iterations, best guess: %s for %s^%s", powIterationLimit, sum, originalBase, exp))
+		}
+	}
+	return sum
+}
+
+// powerApproximation Check exponentialLogarithmicMethod and maclaurinSeriesApproximation to understand the limits of this function
+func powerApproximation(base sdk.Dec, exp sdk.Dec) (sdk.Dec, error) {
 	if !base.IsPositive() {
 		return sdk.Dec{}, fmt.Errorf("base must be greater than 0")
 	}
-	if exp.LTE(sdk.ZeroDec()) {
+	if exp.LT(sdk.ZeroDec()) {
 		return sdk.Dec{}, fmt.Errorf("exp must be greater than 0")
 	}
 	if exp.IsZero() {
@@ -113,6 +206,9 @@ func PowerApproximation(base sdk.Dec, exp sdk.Dec) (sdk.Dec, error) {
 	if exp.Equal(sdk.OneDec()) {
 		return base, nil
 	}
+	if exp.Equal(sdk.OneDec().Neg()) {
+		return sdk.OneDec().Quo(base), nil
+	}
 	if exp.Equal(oneHalf) {
 		output, err := base.ApproxSqrt()
 		if err != nil {
@@ -120,6 +216,29 @@ func PowerApproximation(base sdk.Dec, exp sdk.Dec) (sdk.Dec, error) {
 		}
 		return output, nil
 	}
+	// case where exp can be represented as uint64
+	if exp.IsInteger() && exp.IsPositive() && exp.LTE(sdk.MustNewDecFromStr(strconv.FormatUint(math.MaxUint64, 10))) {
+		return base.Power(uint64(exp.TruncateInt64())), nil
+	}
+
+	if exp.GT(sdk.OneDec()) {
+		return Pow(base, exp), nil
+	}
+
+	if base.GTE(oneHalf) && base.LT(twoDec) {
+		return maclaurinSeriesApproximation(base, exp, powPrecision), nil
+	}
+
+	return exponentialLogarithmicMethod(base, exp)
+}
+
+// exponentialLogarithmicMethod This function can operate on any base value >0,
+// but it loses its accuracy when base is close to 2^k where k is an integer
+// Error propagation is also an issue, when computeLn and computeExp both calculates upto 8 decimal places,
+// if the base is large enough, the error propagates and decreases the inaccuracy.
+// For example, when calculating 1000^2.23, it can calculate 1000^0.23 upto required accuracy but when we multiply this result
+// to 1000^2, the error propagates to other decimal places
+func exponentialLogarithmicMethod(base sdk.Dec, exp sdk.Dec) (sdk.Dec, error) {
 	lnBase, err := computeLn(base)
 	if err != nil {
 		return sdk.Dec{}, err
@@ -129,4 +248,100 @@ func PowerApproximation(base sdk.Dec, exp sdk.Dec) (sdk.Dec, error) {
 		return sdk.Dec{}, err
 	}
 	return expResult, nil
+}
+
+// maclaurinSeriesApproximation This function is very accurate when 0.5 <= base < 2, over 2 it panics
+// When base is extremely close to 2 then this function might panic as it's unable to reach accuracy within desired iterations
+// 0 <= exp < 1.
+func maclaurinSeriesApproximation(originalBase sdk.Dec, exp sdk.Dec, precision sdk.Dec) sdk.Dec {
+	if !originalBase.IsPositive() {
+		panic(fmt.Errorf("base must be greater than 0"))
+	}
+
+	if exp.IsZero() {
+		return sdk.OneDec()
+	}
+
+	// Common case optimization
+	// Optimize for it being equal to one-half
+	if exp.Equal(oneHalf) {
+		output, err := originalBase.ApproxSqrt()
+		if err != nil {
+			panic(err)
+		}
+		return output
+	}
+	// TODO: Make an approx-equal function, and then check if exp * 3 = 1, and do a check accordingly
+
+	// We compute this via taking the maclaurin series of (1 + x)^a
+	// where x = base - 1.
+	// The maclaurin series of (1 + x)^a = sum_{k=0}^{infty} binom(a, k) x^k
+	// Binom(a, k) takes the natural continuation on the first parameter, namely that
+	// Binom(a, k) = N/D, where D = k!, and N = a(a-1)(a-2)...(a-k+1)
+	// Next we show that the absolute value of each term is less than the last term.
+	// Note that the change in term n's value vs term n + 1 is a multiplicative factor of
+	// v_n = x(a - n) / (n+1)
+	// So if |v_n| < 1, we know that each term has a lesser impact on the result than the last.
+	// For our bounds on |x| < 1, |a| < 1,
+	// it suffices to see for what n is |v_n| < 1,
+	// in the worst parameterization of x = 1, a = -1.
+	// v_n = |(-1 + epsilon - n) / (n+1)|
+	// So |v_n| is always less than 1, as n ranges over the integers.
+	//
+	// Note that term_n of the expansion is 1 * prod_{i=0}^{n-1} v_i
+	// The error if we stop the expansion at term_n is:
+	// error_n = sum_{k=n+1}^{infty} term_k
+	// At this point we further restrict a >= 0, so 0 <= a < 1.
+	// Now we take the _INCORRECT_ assumption that if term_n < p, then
+	// error_n < p.
+	// This assumption is obviously wrong.
+	// However our usages of this function don't use the full domain.
+	// With a > 0, |x| << 1, and p sufficiently low, perhaps this actually is true.
+
+	// TODO: Check with our parameterization
+	// TODO: If there's a bug, balancer is also wrong here :thonk:
+
+	base := originalBase.Clone()
+	x, xneg := AbsDifferenceWithSign(base, sdk.OneDec())
+	term := sdk.OneDec()
+	sum := sdk.OneDec()
+	negative := false
+
+	a := exp.Clone()
+	bigK := sdk.NewDec(0)
+	// TODO: Document this computation via taylor expansion
+	for i := int64(1); term.GTE(precision); i++ {
+		// At each iteration, we need two values, i and i-1.
+		// To avoid expensive big.Int allocation, we reuse bigK variable.
+		// On this line, bigK == i-1.
+		c, cneg := AbsDifferenceWithSign(a, bigK)
+		// On this line, bigK == i.
+		bigK.SetInt64(i)
+		term.MulMut(c).MulMut(x).QuoMut(bigK)
+
+		// a is mutated on absDifferenceWithSign, reset
+		a.Set(exp)
+
+		if term.IsZero() {
+			break
+		}
+		if xneg {
+			negative = !negative
+		}
+
+		if cneg {
+			negative = !negative
+		}
+
+		if negative {
+			sum.SubMut(term)
+		} else {
+			sum.AddMut(term)
+		}
+
+		if i == powIterationLimit {
+			panic(fmt.Errorf("failed to reach precision within %d iterations, best guess: %s for %s^%s", powIterationLimit, sum, originalBase, exp))
+		}
+	}
+	return sum
 }

--- a/x/amm/types/pow_approx.go
+++ b/x/amm/types/pow_approx.go
@@ -6,12 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var (
-	ln2    = sdk.MustNewDecFromStr("0.693147180559945309")
-	invLn2 = sdk.MustNewDecFromStr("1.442695040888963407")
-	exp    = sdk.MustNewDecFromStr("2.718281828459045235")
-)
-
 func computeExp(x sdk.Dec) (sdk.Dec, error) {
 	if x.Equal(sdk.ZeroDec()) {
 		return sdk.OneDec(), nil
@@ -25,7 +19,7 @@ func computeExp(x sdk.Dec) (sdk.Dec, error) {
 	}
 
 	// Range reduction: x = k * ln(2) + y
-	k := x.Mul(invLn2).TruncateInt64()
+	k := x.Mul(inverseLn2).TruncateInt64()
 	y := x.Sub(sdk.NewDecFromInt(sdk.NewInt(k)).Mul(ln2))
 
 	expY := sdk.OneDec()
@@ -42,9 +36,9 @@ func computeExp(x sdk.Dec) (sdk.Dec, error) {
 
 	twoPowK := sdk.OneDec()
 	if k > 0 {
-		twoPowK = two.Power(uint64(k))
+		twoPowK = twoDec.Power(uint64(k))
 	} else if k < 0 {
-		twoPowK = sdk.OneDec().Quo(two.Power(uint64(-k)))
+		twoPowK = sdk.OneDec().Quo(twoDec.Power(uint64(-k)))
 	}
 
 	result := expY.Mul(twoPowK)
@@ -72,11 +66,11 @@ func computeLn(x sdk.Dec) (result sdk.Dec, err error) {
 	// To bring x is in the range [0.5, 2]
 	// we use ln(x) = k * ln(2) + ln(z), where z is in [0.5, 2]
 	k := 0
-	for x.GT(two) {
-		x = x.Quo(two)
+	for x.GT(twoDec) {
+		x = x.Quo(twoDec)
 		k++
 	}
-	for x.LT(sdk.OneDec().Quo(two)) {
+	for x.LT(sdk.OneDec().Quo(twoDec)) {
 		x = x.MulInt64(2)
 		k--
 	}
@@ -119,7 +113,7 @@ func PowerApproximation(base sdk.Dec, exp sdk.Dec) (sdk.Dec, error) {
 	if exp.Equal(sdk.OneDec()) {
 		return base, nil
 	}
-	if exp.Equal(one_half) {
+	if exp.Equal(oneHalf) {
 		output, err := base.ApproxSqrt()
 		if err != nil {
 			return sdk.Dec{}, err

--- a/x/amm/types/pow_approx_test.go
+++ b/x/amm/types/pow_approx_test.go
@@ -28,7 +28,7 @@ func TestPowApproximation(t *testing.T) {
 			count++
 		}
 	}
-	lowInaccuracy := count < (iterations / 10)
+	lowInaccuracy := count < ((iterations * 2) / 100) // 2% inaccuracy
 	require.True(t, lowInaccuracy)
 
 }

--- a/x/amm/types/pow_approx_test.go
+++ b/x/amm/types/pow_approx_test.go
@@ -1,0 +1,34 @@
+package types_test
+
+import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/elys-network/elys/x/amm/types"
+	"github.com/stretchr/testify/require"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestPowApproximation(t *testing.T) {
+	precision := sdk.MustNewDecFromStr("0.0001")
+	baseInt := 100
+	count := 0
+	iterations := 100000
+	for i := 0; i < iterations; i++ {
+		numberF := float64(rand.Int63n(int64(baseInt))) + rand.Float64()
+		expF := rand.Float64()
+		number := sdk.MustNewDecFromStr(fmt.Sprintf("%f", numberF))
+		exp := sdk.MustNewDecFromStr(fmt.Sprintf("%f", expF))
+		value, _ := types.PowerApproximation(number, exp)
+		libraryValue := sdk.MustNewDecFromStr(fmt.Sprintf("%f", math.Pow(numberF, expF)))
+		err := libraryValue.Sub(value).Abs()
+		assert := err.LTE(precision)
+		if !assert {
+			count++
+		}
+	}
+	highInaccuracy := count < (iterations / 10)
+	require.True(t, highInaccuracy)
+
+}

--- a/x/amm/types/pow_approx_test.go
+++ b/x/amm/types/pow_approx_test.go
@@ -28,7 +28,7 @@ func TestPowApproximation(t *testing.T) {
 			count++
 		}
 	}
-	highInaccuracy := count < (iterations / 10)
-	require.True(t, highInaccuracy)
+	lowInaccuracy := count < (iterations / 10)
+	require.True(t, lowInaccuracy)
 
 }

--- a/x/amm/types/pow_approx_test.go
+++ b/x/amm/types/pow_approx_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 )
 
+// The test cases here are comparing computed values with go's in built function over float64.
+// How to make sure those are accurate, and they only generate upto 6 decimal places.
 func TestPowApproximation(t *testing.T) {
 	precision := sdk.MustNewDecFromStr("0.0001")
 	baseInt := 100
@@ -30,5 +32,11 @@ func TestPowApproximation(t *testing.T) {
 	}
 	lowInaccuracy := count < ((iterations * 2) / 100) // 2% inaccuracy
 	require.True(t, lowInaccuracy)
+
+	// 2^255 + OneDec - SmallestDec, Max number lies somewhere between 2^256 and 2^255
+	edgeCaseNumber := sdk.MustNewDecFromStr("57896044618658097711785492504343953926634992332820282019728792003956564819968.999999999999999999")
+	edgeCaseExponent := sdk.MustNewDecFromStr("0.999999999999999999")
+	_, err := types.PowerApproximation(edgeCaseNumber, edgeCaseExponent)
+	require.NoError(t, err)
 
 }

--- a/x/amm/types/pow_approx_test.go
+++ b/x/amm/types/pow_approx_test.go
@@ -1,42 +1,139 @@
-package types_test
+package types
 
 import (
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/elys-network/elys/x/amm/types"
 	"github.com/stretchr/testify/require"
-	"math"
-	"math/rand"
 	"testing"
 )
 
-// The test cases here are comparing computed values with go's in built function over float64.
-// How to make sure those are accurate, and they only generate upto 6 decimal places.
-func TestPowApproximation(t *testing.T) {
-	precision := sdk.MustNewDecFromStr("0.0001")
-	baseInt := 100
-	count := 0
-	iterations := 100000
-	for i := 0; i < iterations; i++ {
-		numberF := float64(rand.Int63n(int64(baseInt))) + rand.Float64()
-		expF := rand.Float64()
-		number := sdk.MustNewDecFromStr(fmt.Sprintf("%f", numberF))
-		exp := sdk.MustNewDecFromStr(fmt.Sprintf("%f", expF))
-		value, _ := types.PowerApproximation(number, exp)
-		libraryValue := sdk.MustNewDecFromStr(fmt.Sprintf("%f", math.Pow(numberF, expF)))
-		err := libraryValue.Sub(value).Abs()
-		assert := err.LTE(precision)
-		if !assert {
-			count++
-		}
+func ConditionalPanic(t *testing.T, expectPanic bool, sut func()) {
+	if expectPanic {
+		require.Panics(t, sut)
+		return
 	}
-	lowInaccuracy := count < ((iterations * 2) / 100) // 2% inaccuracy
-	require.True(t, lowInaccuracy)
+	require.NotPanics(t, sut)
+}
 
-	// 2^255 + OneDec - SmallestDec, Max number lies somewhere between 2^256 and 2^255
-	edgeCaseNumber := sdk.MustNewDecFromStr("57896044618658097711785492504343953926634992332820282019728792003956564819968.999999999999999999")
-	edgeCaseExponent := sdk.MustNewDecFromStr("0.999999999999999999")
-	_, err := types.PowerApproximation(edgeCaseNumber, edgeCaseExponent)
-	require.NoError(t, err)
+func TestPowApprox(t *testing.T) {
+	testCases := []struct {
+		expectPanic    bool
+		base           sdk.Dec
+		exp            sdk.Dec
+		powPrecision   sdk.Dec
+		expectedResult sdk.Dec
+	}{
+		{
+			// medium base, small exp
+			base:           sdk.MustNewDecFromStr("0.8"),
+			exp:            sdk.MustNewDecFromStr("0.32"),
+			powPrecision:   sdk.MustNewDecFromStr("0.00000001"),
+			expectedResult: sdk.MustNewDecFromStr("0.93108385"),
+		},
+		{
+			// zero exp
+			base:           sdk.MustNewDecFromStr("0.8"),
+			exp:            sdk.ZeroDec(),
+			powPrecision:   sdk.MustNewDecFromStr("0.00001"),
+			expectedResult: sdk.OneDec(),
+		},
+		{
+			// zero base, this should panic
+			base:         sdk.ZeroDec(),
+			exp:          sdk.OneDec(),
+			powPrecision: sdk.MustNewDecFromStr("0.00001"),
+			expectPanic:  true,
+		},
+		{
+			// large base, small exp
+			base:           sdk.MustNewDecFromStr("1.9999"),
+			exp:            sdk.MustNewDecFromStr("0.23"),
+			powPrecision:   sdk.MustNewDecFromStr("0.000000001"),
+			expectedResult: sdk.MustNewDecFromStr("1.172821461"),
+		},
+		{
+			// large base, large integer exp
+			base:           sdk.MustNewDecFromStr("1.777"),
+			exp:            sdk.MustNewDecFromStr("20"),
+			powPrecision:   sdk.MustNewDecFromStr("0.000000000001"),
+			expectedResult: sdk.MustNewDecFromStr("98570.862372081602"),
+		},
+		{
+			// medium base, large exp, high precision
+			base:           sdk.MustNewDecFromStr("1.556"),
+			exp:            sdk.MustNewDecFromStr("20.9123"),
+			powPrecision:   sdk.MustNewDecFromStr("0.0000000000000001"),
+			expectedResult: sdk.MustNewDecFromStr("10360.058421529811344618"),
+		},
+		{
+			// high base, large exp, high precision
+			base:           sdk.MustNewDecFromStr("1.886"),
+			exp:            sdk.MustNewDecFromStr("31.9123"),
+			powPrecision:   sdk.MustNewDecFromStr("0.00000000000001"),
+			expectedResult: sdk.MustNewDecFromStr("621110716.84727942280335811"),
+		},
+		{
+			// base equal one
+			base:           sdk.MustNewDecFromStr("1"),
+			exp:            sdk.MustNewDecFromStr("123"),
+			powPrecision:   sdk.MustNewDecFromStr("0.00000001"),
+			expectedResult: sdk.OneDec(),
+		},
+		{
+			// base close to 2
 
+			base:         sdk.MustNewDecFromStr("1.999999999999999999"),
+			exp:          sdk.SmallestDec(),
+			powPrecision: powPrecision,
+			// In Python: 1.000000000000000000693147181
+			expectedResult: sdk.OneDec(),
+		},
+		{
+			// base close to 2 and hitting iteration bound
+
+			base:         sdk.MustNewDecFromStr("1.999999999999999999"),
+			exp:          sdk.MustNewDecFromStr("0.1"),
+			powPrecision: powPrecision,
+
+			// In Python: 1.071773462536293164
+
+			expectPanic: true,
+		},
+		{
+			// base close to 2 under iteration limit
+
+			base:         sdk.MustNewDecFromStr("1.99999"),
+			exp:          sdk.MustNewDecFromStr("0.1"),
+			powPrecision: powPrecision,
+
+			// expectedResult: sdk.MustNewDecFromStr("1.071772926648356147"),
+
+			// In Python: 1.071772926648356147102864087
+
+			expectPanic: true,
+		},
+		{
+			// base close to 2 under iteration limit
+
+			base:         sdk.MustNewDecFromStr("1.9999"),
+			exp:          sdk.MustNewDecFromStr("0.1"),
+			powPrecision: powPrecision,
+
+			// In Python: 1.071768103548402149880477100
+			expectedResult: sdk.MustNewDecFromStr("1.071768103548402149"),
+		},
+	}
+
+	for i, tc := range testCases {
+		var actualResult sdk.Dec
+		ConditionalPanic(t, tc.expectPanic, func() {
+			fmt.Println(tc.base)
+			actualResult = PowApprox(tc.base, tc.exp, tc.powPrecision)
+			require.True(
+				t,
+				tc.expectedResult.Sub(actualResult).Abs().LTE(tc.powPrecision),
+				fmt.Sprintf("test %d failed: expected value & actual value's difference should be less than precision, expected: %s, actual: %s, precision: %s", i, tc.expectedResult, actualResult, tc.powPrecision),
+			)
+		})
+	}
 }


### PR DESCRIPTION
## Description
It adds a new function `PowerApproximation` which can calculate power on numbers greater than 2 as well.
The previous function `PowApprox` had that limitation.

The previous function didn't work because `term.MulMut(c).MulMut(x).QuoMut(bigK)` becomes too large for sdk.Dec to store as max allowed number of bits are 315 and max value should be  < 2^256

Closes:
* https://github.com/elys-network/issues/issues/669

