### PR TITLE
fix cli command use statement for perpetual module

### DIFF
--- a/x/perpetual/client/cli/tx_update_stop_loss.go
+++ b/x/perpetual/client/cli/tx_update_stop_loss.go
@@ -14,7 +14,7 @@ import (
 
 func CmdUpdateStopLoss() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-stop-loss [id] [amount]",
+		Use:   "update-stop-loss [amount] [id]",
 		Short: "Broadcast message update-stop-loss",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/x/perpetual/client/cli/tx_update_take_profit_price.go
+++ b/x/perpetual/client/cli/tx_update_take_profit_price.go
@@ -14,7 +14,7 @@ import (
 
 func CmdUpdateTakeProfitPrice() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-take-profit-price [id] [amount]",
+		Use:   "update-take-profit-price [amount] [id]",
 		Short: "Broadcast message update-take-profit-price",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {


### PR DESCRIPTION
## Description
perpetual tx (update-stop-loss and update-take-profit-price) was showing wrong input ordering 